### PR TITLE
REF: tcparse-stcmd run -> main; print to stdout

### DIFF
--- a/tcparse/stcmd.py
+++ b/tcparse/stcmd.py
@@ -65,12 +65,7 @@ def build_arg_parser():
     return parser
 
 
-def main(*, cmdline_args=None):
-    parser = build_arg_parser()
-    return run(parser.parse_args(cmdline_args))
-
-
-def run(args):
+def render(args):
     logger = logging.getLogger('tcparse')
     logger.setLevel(args.log)
     logging.basicConfig()
@@ -131,3 +126,9 @@ def run(args):
     )
 
     return template.render(**template_args)
+
+
+def main(*, cmdline_args=None):
+    parser = build_arg_parser()
+    template = render(parser.parse_args(cmdline_args))
+    print(template)

--- a/tcparse/tests/test_commandline.py
+++ b/tcparse/tests/test_commandline.py
@@ -2,4 +2,4 @@ from ..stcmd import main as stcmd_main
 
 
 def test_stcmd(project_filename):
-    print(stcmd_main(cmdline_args=[project_filename]))
+    stcmd_main(cmdline_args=[project_filename])


### PR DESCRIPTION
Previously, `tcparse-stcmd` output was going to stderr due to how 'console script entry points' work with setuptools. This makes it more explicit, and renames a method for clarity.