### PR TITLE
ENH: add optional pytmc dependency

### DIFF
--- a/tcparse/parse.py
+++ b/tcparse/parse.py
@@ -615,6 +615,11 @@ class Project(TwincatItem):
             return ams_id[:-4]
         return ams_id  # :(
 
+    @property
+    def nested_projects(self):
+        'The nested projects (virtual PLC project) contained in this Project'
+        return self.find(TcSmItem_CNestedPlcProjDef)
+
 
 @_register_type
 class TcSmItem(TwincatItem):

--- a/tcparse/stcmd.py
+++ b/tcparse/stcmd.py
@@ -96,6 +96,14 @@ def render(args):
               for motor in project.find(Symbol_FB_DriveVirtual)]
 
     def get_pytmc(motor, nc_axis, key):
+        '''
+        Find a pytmc pragma by key
+
+        Returns
+        -------
+        value : str or None
+            The first value found, if any
+        '''
         if pytmc is None:
             return None
 
@@ -106,10 +114,14 @@ def render(args):
 
     def get_name(motor, nc_axis):
         'Returns: (motor_prefix, motor_name)'
+        # First check if there is a pytmc pragma
         tmc_name = get_pytmc(motor, nc_axis, 'pv')
         if tmc_name is not None:
+            # PV name specified in the pragma - use it as-is
             return '', tmc_name
 
+        # Fall back to using the NC axis name, replacing underscores/spaces
+        # with the user-specified delimiter
         name = nc_axis.short_name
         name = name.replace(' ', args.delim)
         return args.prefix + args.delim, name.replace('_', args.delim)
@@ -120,7 +132,7 @@ def render(args):
                     for prop in motor.find(Property)
                     if prop.name == 'pytmc'
                     ]
-            for motor, nc_axis in motors
+            for motor, _ in motors
         }
 
     template_motors = [

--- a/tcparse/stcmd.py
+++ b/tcparse/stcmd.py
@@ -142,8 +142,10 @@ def render(args):
              desc=f'{motor.name} / {nc_axis.short_name}',
              egu=nc_axis.units,
              prec=get_pytmc(motor, nc_axis, 'precision') or '3',
-             additional_fields=get_pytmc(motor, nc_axis, 'additional_fields') or '',
-             amplifier_flags=get_pytmc(motor, nc_axis, 'amplifier_flags') or '0',
+             additional_fields=get_pytmc(motor, nc_axis,
+                                         'additional_fields') or '',
+             amplifier_flags=get_pytmc(motor, nc_axis,
+                                       'amplifier_flags') or '0',
              )
         for motor, nc_axis in motors
     ]

--- a/tcparse/stcmd.py
+++ b/tcparse/stcmd.py
@@ -54,8 +54,8 @@ def build_arg_parser():
     )
 
     parser.add_argument(
-        '--only-motors', default=False, action='store_true',
-        help='Do not parse TMC file for non-motor records'
+        '--all-records', default=False, action='store_true',
+        help='Parse the TMC file for non-motor records as well'
     )
 
     parser.add_argument(
@@ -190,11 +190,11 @@ def render(args):
     ads_port = motors[0][0].module.ads_port if motors else 851
 
     additional_db_files = []
-    if not args.only_motors:
+    if args.all_records:
         if pytmc is None:
-            logger.error('pytmc unavailable; '
-                         'did you mean to use --only-motors?')
+            logger.error('pytmc unavailable; cannot use --all-records.')
             sys.exit(1)
+
         for proj in project.nested_projects:
             rendered_db = render_pytmc(proj.tmc.filename, dbd=args.dbd)
             if not rendered_db:

--- a/tcparse/templates/stcmd_default.cmd
+++ b/tcparse/templates/stcmd_default.cmd
@@ -72,6 +72,10 @@ dbLoadRecords("EthercatMCreadback.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME
 dbLoadRecords("EthercatMCdebug.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME=$(MOTOR_NAME), MOTOR_PORT=$(MOTOR_PORT), AXIS_NO=$(AXIS_NO), PREC=3")
 
 {% endfor %}
+{% for db in additional_db_files %}
+dbLoadRecords("db/{{ db.file }}", "{{ db.macros }}")
+
+{% endfor %}
 cd "$(TOP)"
 
 dbLoadRecords("db/iocAdmin.db", "P={{prefix}},IOC={{prefix}}" )

--- a/tcparse/templates/stcmd_default.cmd
+++ b/tcparse/templates/stcmd_default.cmd
@@ -57,18 +57,19 @@ asynSetTraceInfoMask("$(ASYN_PORT)", -1, 5)
 
 {% for motor in motors %}
 epicsEnvSet("AXISCONFIG",      "{{motor.axisconfig}}")
-epicsEnvSet("MOTOR_NAME",      "{{motor.name}}")
 epicsEnvSet("AXIS_NO",         "{{motor.axis_no}}")
 epicsEnvSet("DESC",            "{{motor.desc}}")
 epicsEnvSet("EGU",             "{{motor.egu}}")
 epicsEnvSet("PREC",            "{{motor.prec}}")
 epicsEnvSet("ECAXISFIELDINIT", "{{motor.additional_fields}}")
 epicsEnvSet("AMPLIFIER_FLAGS", "{{motor.amplifier_flags}}")
+epicsEnvSet("MOTOR_PREFIX",    "{{motor.name[0]}}")
+epicsEnvSet("MOTOR_NAME",      "{{motor.name[1]}}")
 
 EthercatMCCreateAxis("$(MOTOR_PORT)", "$(AXIS_NO)", "$(AMPLIFIER_FLAGS)", "$(AXISCONFIG)")
-dbLoadRecords("EthercatMC.template", "PREFIX=$(PREFIX), MOTOR_NAME=$(MOTOR_NAME), R=$(MOTOR_NAME)-, MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO), DESC=$(DESC), PREC=$(PREC) $(ECAXISFIELDINIT)")
-dbLoadRecords("EthercatMCreadback.template", "PREFIX=$(PREFIX), MOTOR_NAME=$(MOTOR_NAME), R=$(MOTOR_NAME)-, MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO), DESC=$(DESC), PREC=$(PREC) ")
-dbLoadRecords("EthercatMCdebug.template", "PREFIX=$(PREFIX), MOTOR_NAME=$(MOTOR_NAME), MOTOR_PORT=$(MOTOR_PORT), AXIS_NO=$(AXIS_NO), PREC=3")
+dbLoadRecords("EthercatMC.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME=$(MOTOR_NAME), R=$(MOTOR_NAME)-, MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO), DESC=$(DESC), PREC=$(PREC) $(ECAXISFIELDINIT)")
+dbLoadRecords("EthercatMCreadback.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME=$(MOTOR_NAME), R=$(MOTOR_NAME)-, MOTOR_PORT=$(MOTOR_PORT), ASYN_PORT=$(ASYN_PORT), AXIS_NO=$(AXIS_NO), DESC=$(DESC), PREC=$(PREC) ")
+dbLoadRecords("EthercatMCdebug.template", "PREFIX=$(MOTOR_PREFIX), MOTOR_NAME=$(MOTOR_NAME), MOTOR_PORT=$(MOTOR_PORT), AXIS_NO=$(AXIS_NO), PREC=3")
 
 {% endfor %}
 cd "$(TOP)"


### PR DESCRIPTION
If available, grabs PV name, precision, additional fields, and amplifier flags from pytmc pragmas

TODO
* `pytmc` not yet a test dependency
* The von hamos project in the test suite does not have any pragmas; need to update that project or add a new one

cc @ZLLentz 